### PR TITLE
Edit command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,13 +21,14 @@ All sub-commands use `/note` as a root.
 - `shift` Removes the bottom-most item.
 - `remove <index>` Removes the specified item.
 
-### Reorganizing
+### Editing
+- `edit <index> <text>` Overwrites an existing item. Auto-completion will offer you the old value.
 - `bump <index>` Moves an item one place upward.
-- `bump <index> <offset>` Moves an item the given amount of places. Positive values move upwrad, negative values move downard.
-- `move <from> <to>` Moves onr item from one index to another.
+- `bump <index> <offset>` Moves an item the given amount of places. Positive values move upward, negative values move downward.
+- `move <from> <to>` Moves an item from one index to another.
 
 ### Hud-control
-- `hide <bool>` Hides or show the backlog on the HUD.
+- `hide <bool>` Toogles the backlog hud On or Off. Can be called with no argument.
 
 ### Debug
 These commands shouldn't ever need to be used for normal usage.
@@ -36,8 +37,8 @@ These commands shouldn't ever need to be used for normal usage.
 
 ## File locations
 
-Backlog files are saved as JSON arrays.
+Backlogs are saved as JSON arrays.
 
 For singleplayer worlds, they are saved at the root of the world's directory as `backlog.json`
 
-For multiplayer, they are saved under `.minecraft/remote_backlogs/`, using the ip/address and port of the server as the file name. LAN world are handled the same way.
+For multiplayer, they are saved under `.minecraft/remote_backlogs/`, using the ip/address and port of the server as the file name. LAN worlds are handled the same way.

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.19.4+build.2
 loader_version=0.14.22
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.1.0
 maven_group=tk.estecka.backburner
 archives_base_name=back-burner
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.19.4+build.2
 loader_version=0.14.22
 
 # Mod Properties
-mod_version=1.0.0
+mod_version=1.0.1
 maven_group=tk.estecka.backburner
 archives_base_name=back-burner
 

--- a/src/main/java/tk/estecka/backburner/BacklogCommands.java
+++ b/src/main/java/tk/estecka/backburner/BacklogCommands.java
@@ -301,7 +301,7 @@ public class BacklogCommands
 			return 0;
 		}
 		
-		if (index < 0 || index > items.size()){
+		if (index < 0 || index > items.size()-1){
 			context.getSource().sendError(Text.literal(String.format("Index %d out of bounds. Max %d.", index, items.size()-1)));
 			return -1;
 		}

--- a/src/main/java/tk/estecka/backburner/BacklogCommands.java
+++ b/src/main/java/tk/estecka/backburner/BacklogCommands.java
@@ -3,14 +3,18 @@ package tk.estecka.backburner;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal;
+import java.util.concurrent.CompletableFuture;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.argument;
 import static com.mojang.brigadier.arguments.BoolArgumentType.bool;
 import static com.mojang.brigadier.arguments.BoolArgumentType.getBool;
@@ -124,9 +128,10 @@ public class BacklogCommands
 				)
 			)
 		);
-		root.then(literal("set")
+		root.then(literal("edit")
 			.then(argument(INDEX_ARG, integer(0))
 				.then(argument(VALUE_ARG, greedyString())
+					.suggests(BacklogCommands::EditAutofill)
 					.executes(BacklogCommands::Set)
 				)
 			)
@@ -209,6 +214,14 @@ public class BacklogCommands
 /******************************************************************************/
 /* # Command Logic                                                            */
 /******************************************************************************/
+
+	static private CompletableFuture<Suggestions> EditAutofill(final CommandContext<FabricClientCommandSource> context, final SuggestionsBuilder builder){
+		final var items = BacklogData.instance.content;
+		int i = getInteger(context, INDEX_ARG);
+		if (0 <= i && i < items.size())
+			builder.suggest(items.get(i));
+		return builder.buildFuture();
+	}
 
 	static private void	PrintEntry(CommandContext<FabricClientCommandSource> context, Text prefix, int index, String value) {
 		var msg = MutableText.of(Text.empty().getContent())

--- a/src/main/java/tk/estecka/backburner/BacklogHud.java
+++ b/src/main/java/tk/estecka/backburner/BacklogHud.java
@@ -17,7 +17,7 @@ public class BacklogHud
 extends DrawableHelper
 {
 	static private final Identifier TEXTURE_ID = new Identifier("backburner", "textures/gui/backlog.png");
-	static private final Rect2i ICON_REGION = new Rect2i(9, 9, 9, 9);
+	static private final Rect2i ICON_REGION = new Rect2i(7, 8, 11, 10);
 
 	static private final Rect2i HEADER_REGION = new Rect2i( 7, 26, 83, 15);
 	static private final Rect2i HEADER_PATCH  = new Rect2i(20,  10, 61, 1);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,7 +2,7 @@
 	"schemaVersion": 1,
 	"id": "backburner",
 	"version": "${version}",
-	"name": "The back-burner",
+	"name": "Back-burner",
 	"description": "Clientside to-do list for forgetful people.",
 	"authors": [
 		"Estecka"


### PR DESCRIPTION
- Added the `edit` command. The old value can be auto-filled.
- `remove` no longer falls back to the closest item when the index is out of bounds.
- `hide` can be called with no arguments
- Fixed the icon offset when hiding the hud.